### PR TITLE
Port ansible 2.9

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,7 +13,7 @@
     # NOTE: Output of 'yum repolist' may start with '*' if the repository has
     # metalink data and the latest metadata is not local or with '!' if the
     # repository has metadata that is expired.
-    when: not postgresql_repos_res.stdout | search('\n(\*|!)?' + postgresql_rhel_rhscl_repo)
+    when: not postgresql_repos_res.stdout is search('\n(\*|!)?' + postgresql_rhel_rhscl_repo)
 
   when: ansible_distribution == "RedHat"
 

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -80,13 +80,12 @@
     # time.
     - name: Remove the previous syspaths packages
       package:
-        name: "{{ postgresql_upgrade_old_scl_name }}-{{ item }}"
+        name:
+          - "{{ postgresql_upgrade_old_scl_name }}-syspaths"
+          - "{{ postgresql_upgrade_old_scl_name }}-postgresql-syspaths"
+          - "{{ postgresql_upgrade_old_scl_name }}-postgresql-server-syspaths"
+          - "{{ postgresql_upgrade_old_scl_name }}-postgresql-contrib-syspaths"
         state: absent
-      with_items:
-        - syspaths
-        - postgresql-syspaths
-        - postgresql-server-syspaths
-        - postgresql-contrib-syspaths
       when: postgresql_install_syspaths
 
   when: postgresql_upgrade_installed_versions | length == 1


### PR DESCRIPTION
Changes:
- Filters are replaced with Jinja tests
- Package modules support lists of packages. Squash actions (ansible.cfg) and with_items notation is deprecated since Ansible 2.7.
