### PR TITLE
Add setting to disable local PostgreSQL installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,9 @@ Variables in ``defaults/main.yml``:
 +-----------------------------------------+----------+--------------------------------------------+
 |                Name                     |   Type   |                Description                 |
 +=========================================+==========+============================================+
+| ``postgresql_local_enabled``            | boolean  | Indicates whether the postgres role will   |
+|                                         |          | be installed locally.                      |
++-----------------------------------------+----------+--------------------------------------------+
 | ``postgresql_conf_listen_addresses``    | string   | Comma-separeted list of IP addresses to    |
 |                                         |          | listen on.                                 |
 |                                         |          |                                            |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+postgresql_local_enabled: true
+
 postgresql_conf_listen_addresses: "*"
 postgresql_conf_password_encryption: scram-sha-256
 


### PR DESCRIPTION
This setting is added so this role can be disabled from the playbook, depending on the inventory configuration.